### PR TITLE
fix(gha): grant required permissions for Mise PRs and Releases

### DIFF
--- a/.github/workflows/mise.yaml
+++ b/.github/workflows/mise.yaml
@@ -2,6 +2,10 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: "Mise"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,9 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: "Release"
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
   schedule:
@@ -11,7 +14,14 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Get Previous Release Tag and Determine Next Tag
         id: determine-next-tag
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

This PR fixes the failing GitHub Actions workflows by granting the necessary permissions for the Mise and Release workflows to function properly.

## Changes Made

### Repository-level Changes
- Updated repository workflow permissions to allow PR creation (, )

### Workflow Changes
- **Mise workflow ()**:
  - Added top-level  block with  and 
  - Maintains existing job-level permissions for clarity
  
- **Release workflow ()**:
  - Added top-level  block with 
  - Added explicit checkout step with  for better release notes generation
  - Maintains existing job-level permissions

## Issues Fixed

- ❌ **Mise workflow**: 'GitHub Actions is not permitted to create or approve pull requests'
- ❌ **Release workflow**: 'Error 403: Resource not accessible by integration'

## Testing Plan

The workflows will be tested with:
1. Manual dispatch of Mise workflow to validate PR creation
2. Test release creation to validate release permissions
3. Monitor next scheduled runs

## Notes

- All workflows continue to use  (the default token) for security
- Changes follow the principle of least privilege
- Both repository-level and workflow-level permissions are now properly configured