### PR TITLE
fix(redisinsight): remove rollingUpdate when using Recreate

### DIFF
--- a/kubernetes/apps/databases/redisinsight/app/deployment.yaml
+++ b/kubernetes/apps/databases/redisinsight/app/deployment.yaml
@@ -10,6 +10,7 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app: redisinsight


### PR DESCRIPTION
## Why
Flux reconciliation fails for `Deployment/databases/redisinsight` with:

`spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy type is 'Recreate'`

The live object still has `rollingUpdate` set from previous state; setting `type: Recreate` alone is not enough to clear it.

## What
- explicitly set `spec.strategy.rollingUpdate: null` while keeping `spec.strategy.type: Recreate`

## Result
This allows the API server validation to pass and lets Flux apply the redisinsight deployment update cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, declarative manifest change limited to Deployment update strategy; main impact is how pods are replaced during rollout.
> 
> **Overview**
> Updates the `redisinsight` Deployment strategy by explicitly setting `spec.strategy.rollingUpdate: null` while using `type: Recreate`, ensuring the field is cleared during apply.
> 
> This prevents Kubernetes/Flux validation failures where `rollingUpdate` is forbidden for `Recreate`, allowing reconciliation of the Deployment to succeed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01e82f556719e894f9571d971d762d39d9c37fd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->