### PR TITLE
fix(redisinsight): use no-overlap rollout for RWO PVC

### DIFF
--- a/kubernetes/apps/databases/redisinsight/app/deployment.yaml
+++ b/kubernetes/apps/databases/redisinsight/app/deployment.yaml
@@ -9,8 +9,10 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: Recreate
-    rollingUpdate: null
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: redisinsight


### PR DESCRIPTION
## Why
`Recreate` strategy with `rollingUpdate` cleanup did not reconcile cleanly in Flux and kept failing dry-run validation.

The underlying operational issue is RWO PVC multi-attach during rollout.

## What
- switch redisinsight deployment strategy to explicit `RollingUpdate`
- set `maxSurge: 0` and `maxUnavailable: 1`

## Result
For a single-replica deployment this performs a no-overlap rollout (old pod goes down before new pod starts), preventing RWO multi-attach while avoiding the `Recreate` validation issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small manifest-only change that adjusts rollout behavior; primary risk is brief downtime during updates due to `maxUnavailable: 1` on a single replica.
> 
> **Overview**
> Updates the `redisinsight` Kubernetes `Deployment` update strategy from `Recreate` to an explicit `RollingUpdate` configured as *no-overlap* (`maxSurge: 0`, `maxUnavailable: 1`) for the single-replica rollout.
> 
> This avoids Flux/dry-run validation issues tied to `Recreate`+`rollingUpdate` fields and prevents RWO PVC multi-attach during upgrades by ensuring the old pod terminates before the new one starts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c29fe8582a8915631f77cd7a7795fae22f28130. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->