### PR TITLE
fix(zero-export-controller): trust binary_sensor.*_reachable state regardless of last_updated age

### DIFF
--- a/kubernetes/apps/home-automation/zero-export-controller/app/controller.py
+++ b/kubernetes/apps/home-automation/zero-export-controller/app/controller.py
@@ -218,7 +218,10 @@ async def fetch_inverters(ha: HAClient, names: list[str]) -> list[InverterState]
         power = states.get(f"sensor.{name}_power")
         reach = states.get(f"binary_sensor.{name}_reachable")
         power_w = power.numeric if power and power.numeric is not None else 0.0
-        reachable = bool(reach and reach.is_on and not reach.is_stale)
+        # binary_sensor.*_reachable only updates last_updated on transitions; a
+        # stable-on sensor will look "stale" but is in fact authoritative. HA
+        # surfaces lost contact as state="unavailable", which .is_on rejects.
+        reachable = bool(reach and reach.is_on)
         out.append(InverterState(name=name, power_w=power_w, reachable=reachable))
     return out
 


### PR DESCRIPTION
## Summary
Follow-up to #137. In the live DRY_RUN deployment the controller logs `limits={'s1': 0, 's2': 0, 's3': 0}` at midday with 580+ W of PV and all three inverters reachable. Root cause: `fetch_inverters` zeroed any inverter whose `binary_sensor.*_reachable` had a stale `last_updated`. HA only bumps `last_updated` on state transitions, so a stably-reachable sensor reads as "stale" forever. HA surfaces real loss-of-contact as `state="unavailable"`, which `EntityState.is_on` already rejects, so the staleness check is redundant and actively harmful.

One-line fix in `controller.py:fetch_inverters`:

```diff
-        reachable = bool(reach and reach.is_on and not reach.is_stale)
+        # binary_sensor.*_reachable only updates last_updated on transitions; a
+        # stable-on sensor will look "stale" but is in fact authoritative. HA
+        # surfaces lost contact as state="unavailable", which .is_on rejects.
+        reachable = bool(reach and reach.is_on)
```

## Why this is a hotfix, not just cosmetic
Today (DRY_RUN=true, kill switch ON) the bug only produces misleading log lines and zeroed Prometheus gauges. **If the operator flipped DRY_RUN off with this bug in place, the controller would `number.set_value` 0 W on every inverter** instead of the spec'd safe distribution, forcing PV production to zero whenever the reachable sensors were quiet (i.e. almost always). That is the opposite of the intended behavior and would erase the entire point of the controller.

## Source-of-truth alignment
The cluster ships `controller.py` verbatim from `/Users/mu/code/tibber-openDTU-home-assitant-solar-monitor/controller.py` via configMapGenerator. After this PR `diff` between the two is empty again.

## Test plan
- [ ] Flux reconciles, ConfigMap hash changes, pod rolls.
- [ ] New pod logs show `zero-export-controller starting (dry_run=True)`.
- [ ] Within ~30 s `grid=… pv=… target=-50W desired=… limits={...}` lines show **non-zero** per-inverter limits at midday.
- [ ] Sum of per-inverter limits ≤ 800 W in every line (legal Bagatellgrenze).
- [ ] Still DRY_RUN; only `[dry-run] would set ...` log lines, no actual `number.set_value` writes.
- [ ] No new AlertManager alerts for `zero-export-controller`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)