### PR TITLE
feat(homepage): add Balkonkraftwerk tile under Home Automation

### DIFF
--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -115,6 +115,12 @@ spec:
                 href: http://192.168.32.201
                 description: Epson ES-580W
                 ping: 192.168.32.201
+        - "Home Automation":
+            - Balkonkraftwerk:
+                href: https://hass.${SECRET_DOMAIN}/dashboard-balkonkraftwerk
+                icon: sun-panel.png
+                description: Balcony PV zero-export dashboard
+                ping: hass.${SECRET_DOMAIN}
         - Monitoring:
             - Alertmanager:
                 href: https://alertmanager.${SECRET_DOMAIN}


### PR DESCRIPTION
## Summary

- Phase 4b of the zero-export-controller plan: adds a Homepage tile linking to the Balkonkraftwerk dashboard hosted in Home Assistant.
- One static link tile under a new `Home Automation` services group (the layout group was already declared but unpopulated).
- Mirrors the OpenDTU tile style (`href` + `icon` + `description` + `ping`) — no live HA widgets are plumbed in this cluster, so per the skip-criteria this is a link-only tile.

## Why no live data?

Homepage in this cluster is configured purely with static YAML and the built-in `kubernetes`, `resources`, `datetime`, `openmeteo` widgets. There is no existing `homeassistant` widget, no `customapi` widget, and no HA long-lived token wired into Homepage. Plumbing HA-as-data-source was explicitly out-of-scope per the plan's skip-criteria.

## Test plan

- [ ] `flux diff` shows only the homepage HelmRelease values change.
- [ ] After Flux reconciles, the new Balkonkraftwerk tile renders in the `Home Automation` group on the Homepage UI.
- [ ] Clicking the tile lands on `https://hass.${SECRET_DOMAIN}/dashboard-balkonkraftwerk`.
- [ ] Ping indicator turns green (Homepage successfully pings the HA hostname).

🤖 Generated with [Claude Code](https://claude.com/claude-code)