### PR TITLE
feat(zero-export-controller): add ServiceMonitor + PrometheusRule (Phase 4a)

### DIFF
--- a/kubernetes/apps/home-automation/zero-export-controller/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/zero-export-controller/app/kustomization.yaml
@@ -3,6 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./servicemonitor.yaml
+  - ./prometheusrule.yaml
 configMapGenerator:
   - name: zero-export-controller-source
     files:

--- a/kubernetes/apps/home-automation/zero-export-controller/app/prometheusrule.yaml
+++ b/kubernetes/apps/home-automation/zero-export-controller/app/prometheusrule.yaml
@@ -1,0 +1,99 @@
+---
+# ZEC-specific functional alerts. Pod-health alerts (PodNotReady, CrashLooping,
+# Restarted) live separately in
+#   kubernetes/apps/monitoring/kube-prometheus-stack/app/zero-export-controller-alerts.yaml
+# per the cluster's centralized convention. This file holds the controller-
+# domain alerts that depend on metrics emitted by the controller itself.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: zero-export-controller
+  labels:
+    app.kubernetes.io/name: kube-prometheus-stack
+    app.kubernetes.io/part-of: kube-prometheus-stack
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: zero-export-controller
+      interval: 30s
+      rules:
+        # --- ZECPodDown ----------------------------------------------------
+        # Warn (not critical) if the deployment has zero available replicas
+        # for >3min during daylight hours. Outside daylight, the controller
+        # being down has no effect on inverter limits (no PV production).
+        # 06:00-22:00 Europe/Berlin covers both CET (UTC+1) and CEST (UTC+2)
+        # with a small buffer: hour() in [4, 21) UTC.
+        - alert: ZECPodDown
+          expr: |
+            (
+              kube_deployment_status_replicas_available{namespace="home-automation",deployment="zero-export-controller"} == 0
+            )
+            and on() (hour() >= 4 and hour() < 21)
+          for: 3m
+          labels:
+            severity: warning
+            category: home-automation
+            component: zero-export-controller
+          annotations:
+            summary: Zero-export controller is down during daylight
+            description: |
+              Deployment zero-export-controller has 0 available replicas for >3min
+              during daylight (06:00-22:00 Europe/Berlin). Inverter power limits
+              are not being updated; PV production may be exporting to grid or
+              clamped to last-known limits.
+
+        # --- ZECExportSustained --------------------------------------------
+        # Grid power < -100W (i.e. exporting more than 100W) for >2min while
+        # the controller is supposed to be holding zero export.
+        - alert: ZECExportSustained
+          expr: zec_grid_power_watts < -100
+          for: 2m
+          labels:
+            severity: warning
+            category: home-automation
+            component: zero-export-controller
+          annotations:
+            summary: Sustained grid export detected ({{ $value | printf "%.0f" }}W)
+            description: |
+              Grid power has been below -100W (exporting) for more than 2 minutes.
+              The zero-export controller is not bringing inverters down fast
+              enough, or an inverter is ignoring its setpoint. Investigate
+              zec_inverter_limit_watts vs zec_inverter_power_watts.
+
+        # --- ZECOverLegalCap -----------------------------------------------
+        # Sum of per-inverter ACTUAL output exceeds the legal cap (>850W) for
+        # >30s. This is a regulatory compliance alert: critical severity.
+        - alert: ZECOverLegalCap
+          expr: sum(zec_inverter_power_watts) > 850
+          for: 30s
+          labels:
+            severity: critical
+            category: home-automation
+            component: zero-export-controller
+          annotations:
+            summary: Total inverter output exceeds 850W legal cap ({{ $value | printf "%.0f" }}W)
+            description: |
+              Sum of zec_inverter_power_watts across all inverters exceeds the
+              850W legal feed-in cap for >30s. This is a regulatory compliance
+              issue. Verify per-inverter limits are being honored and that the
+              controller's cap_w setting is correct.
+
+        # --- ZECLoopStalled ------------------------------------------------
+        # Loop iteration counter has not advanced for >3min while the pod is
+        # up. Indicates the control loop is stuck (deadlock, blocked HTTP,
+        # exception in non-fatal path).
+        - alert: ZECLoopStalled
+          expr: |
+            rate(zec_loop_iterations_total[5m]) == 0
+            and on() kube_deployment_status_replicas_available{namespace="home-automation",deployment="zero-export-controller"} > 0
+          for: 3m
+          labels:
+            severity: warning
+            category: home-automation
+            component: zero-export-controller
+          annotations:
+            summary: Zero-export controller loop has stalled
+            description: |
+              zec_loop_iterations_total has not incremented in the last 5min
+              while the pod is reported as available. The control loop is
+              stuck. Check pod logs for blocked HTTP calls or exceptions.

--- a/kubernetes/apps/home-automation/zero-export-controller/app/servicemonitor.yaml
+++ b/kubernetes/apps/home-automation/zero-export-controller/app/servicemonitor.yaml
@@ -1,0 +1,33 @@
+---
+# Explicit ServiceMonitor for zero-export-controller.
+#
+# Note: the bjw-s app-template chart also generates a ServiceMonitor (named
+# `zero-export-controller`) via helmrelease.yaml's `serviceMonitor:` block, but
+# the kube-prometheus-stack operator does not currently include chart-generated
+# SMs from this namespace in Prometheus' scrape config (cf. pallet-price-monitor
+# which exhibits the same symptom). All other working ServiceMonitors in the
+# cluster are explicit YAML — match that convention here.
+#
+# This SM uses a distinct name (-metrics suffix) to avoid colliding with the
+# chart-generated one. A subsequent change can disable the chart's serviceMonitor
+# block once we confirm scraping works via this resource.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: zero-export-controller-metrics
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - home-automation
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zero-export-controller
+      app.kubernetes.io/instance: zero-export-controller
+  endpoints:
+    - port: metrics
+      path: /metrics
+      scheme: http
+      interval: 30s
+      scrapeTimeout: 15s


### PR DESCRIPTION
## Summary

- Adds explicit `ServiceMonitor` (`zero-export-controller-metrics`) so Prometheus actually scrapes the `zec_*` metrics. The chart-generated SM exists in K8s but is not picked up by the kube-prometheus-stack operator in this cluster (same symptom as `pallet-price-monitor`); every other working SM here is explicit YAML.
- Adds `PrometheusRule` `zero-export-controller` with 4 functional alerts:
  - `ZECPodDown` (warning, >3 min during daylight 06:00–22:00 Europe/Berlin, gated via `hour() in [4,21) UTC`)
  - `ZECExportSustained` (warning, `zec_grid_power_watts < -100` for 2 min)
  - `ZECOverLegalCap` (critical, `sum(zec_inverter_power_watts) > 850` for 30 s — regulatory cap)
  - `ZECLoopStalled` (warning, `rate(zec_loop_iterations_total[5m]) == 0` while pod available, 3 min)
- Pod-health alerts (PodNotReady/CrashLooping/Restarted) already exist in `monitoring/kube-prometheus-stack/app/zero-export-controller-alerts.yaml` and are unchanged.
- Does NOT touch the controller source code, helmrelease env, or DRY_RUN — controller is LIVE.

## Verification

- [x] `kustomize build` renders cleanly
- [x] `task kubeconform` passes for both new files (583 valid; 2 pre-existing errors in `pallet-price-monitor/config/` unrelated)
- [x] All 4 PromQL expressions parsed by live Prometheus (`/api/v1/query` returns `status: success`)
- [x] `flux diff` shows ONLY the 2 new resources, no drift on existing ones
- [ ] Post-merge: `kubectl get servicemonitor zero-export-controller-metrics -n home-automation` returns the resource
- [ ] Post-merge: `kubectl get prometheusrule zero-export-controller -n home-automation` returns the resource
- [ ] Post-merge: `up{job=~".*zero-export.*"}` and `zec_grid_power_watts` show up in Prometheus
- [ ] Post-merge: `ALERTS{alertname=~"ZEC.*"}` lists the 4 alerts as inactive (none should fire under normal operation)

## Notes

- Grafana dashboard skipped — the cluster's existing convention has dashboards living centrally in kube-prometheus-stack values, not as sidecar-discovered ConfigMaps per app. Out of scope for this change; can be added later as a separate PR if desired.
- Follow-up (separate PR): once this SM proves out, remove the chart's `serviceMonitor:` block from `helmrelease.yaml` so we don't carry a duplicate (currently-non-functional) SM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)