### PR TITLE
chore(hooks): whitelist public-identifier Secret keys (username, etc.)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -62,7 +62,31 @@ SKIP_TYPES = {
     "bootstrap.kubernetes.io/token",
     "helm.sh/release.v1",
 }
-SKIP_KEY_NAMES = {"TIMEZONE", "TZ", "tz", "timezone", "ca.crt"}
+# Whitelist Secret keys whose values are public identifiers, not credentials.
+# Decoded values from these keys are *never* added to the literals scan list,
+# because flagging them creates false positives the moment the same identifier
+# (a GitHub org name, an OCI image coordinate, a timezone string) shows up in
+# any committed manifest.
+#
+# Selection rule: a key qualifies only if its value is, by convention, public
+# coordinates that may legitimately appear verbatim in YAML manifests. Adding
+# a key here means "if a real secret is ever stored under this key it will
+# slip past Layer 1" — so we keep the list narrow and identifier-only.
+#
+# Current entries:
+#   TIMEZONE, TZ, tz, timezone — IANA tz strings (Europe/Berlin etc.)
+#   ca.crt                     — X.509 CA bundles (handled by BEGIN CERT skip too)
+#   username                   — basic-auth / GHCR / git pull username (e.g.
+#                                an org or repo-owner handle); the password
+#                                is the actual secret and is in a different
+#                                key (`password`, `token`, `.dockerconfigjson`)
+#   repository, repo           — git/OCI repository coordinates
+#   org, organization          — GitHub/GitLab org slugs
+#   image                      — fully qualified image references
+SKIP_KEY_NAMES = {
+    "TIMEZONE", "TZ", "tz", "timezone", "ca.crt",
+    "username", "repository", "repo", "org", "organization", "image",
+}
 # Pure-lowercase dictionary-like words (no digits, no special chars) — these
 # overlap with common technical terms (postgres, authentik, placeholder, etc.)
 # and cause false positives. Real secrets have entropy markers (digits, case,


### PR DESCRIPTION
## Problem

Layer 1 of `.githooks/pre-commit` decodes every cluster Secret value and grep-F's staged files against them, catching rotated passwords / domain leaks even when the staged change isn't itself a Secret.

Side effect: legitimate basic-auth `username` values (a GitHub org handle, a GHCR pull username) are public-by-convention identifiers that intentionally appear verbatim in committed manifests. They shouldn't poison the literals list.

**Concrete false-positive:**
```
flux-system/github-k8s-self-ai-ops.data.username = "<gh-org-handle>"
```
blocks any commit that adds e.g. `ghcr.io/<gh-org-handle>/<image>:<tag>` — including the in-flight zero-export-controller GHCR migration.

## Fix

Extend `SKIP_KEY_NAMES` in `.githooks/pre-commit` with keys whose values are public coordinates rather than credentials:

| key | rationale |
|---|---|
| `username` | basic-auth / GHCR pull username — handle, not password |
| `repository`, `repo` | git/OCI repo path |
| `org`, `organization` | GitHub/GitLab org slug |
| `image` | fully-qualified image reference |

Each addition is documented inline so future readers can audit why it's safe.

## Conservative scope

Deliberately **not** adding:
- `user`, `login` — too generic; could match real credential fields in third-party charts
- `*_USERNAME` (DB_USERNAME, API_USERNAME, SMTP_USERNAME, …) — can contain email-format usernames or service-account names that *are* PII / attack-surface info

## Tradeoff acknowledged

A real secret stored under a key literally named `username` would slip past Layer 1. Acceptable because:
- Layer 2 still enforces `.sops.yaml` encryption
- Layer 3 still pattern-matches tokens, JWTs, AWS keys, password=… patterns, DB connection strings
- Storing a credential under a key named `username` is not a pattern in this repo

## Verification

The commit on this branch passes the modified hook on itself (the diff to `.githooks/pre-commit` is reviewed by the new logic). Literals-cache count drops by ~1 (the org-handle no longer added).

## Unblocks

`refactor(zero-export-controller): switch from ConfigMap source mount to GHCR image v0.1.0` — that PR's helmrelease.yaml references `ghcr.io/<gh-org>/zero-export-controller:0.1.0` and is currently blocked by this false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)