### PR TITLE
feat(zero-export-controller): bump to v0.3.0 — saturation-aware write deadband

### DIFF
--- a/kubernetes/apps/home-automation/zero-export-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zero-export-controller/app/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
           app:
             image:
               repository: ghcr.io/nachtschatt3n/zero-export-controller
-              tag: 0.2.0
+              tag: 0.3.0
               pullPolicy: IfNotPresent
             env:
               - name: TZ


### PR DESCRIPTION
## Summary

Bumps `zero-export-controller` from v0.2.0 to v0.3.0 (image digest `sha256:f3933b881e8288b8ec1c876a94534007ef8733812cf28096ca639172807db369`).

v0.3.0 introduces a **saturation-aware write deadband**: when grid import exceeds `SATURATION_GRID_THRESHOLD_W` (default 400 W), the per-write deadband widens from 5 W to `SATURATION_DEADBAND_W` (default 50 W), suppressing noise-driven writes caused by Tibber Pulse jitter (~±20 W).

Upstream release notes: https://github.com/nachtschatt3n/zero-export-controller/releases/tag/v0.3.0

## Why

Pre-rollout baseline on v0.2.0: **26 `number.set_value` calls in a 5-minute window** under heavy-import conditions (grid 539–728 W, well above the 400 W saturation threshold). Most of those writes are jitter — the underlying limit decision is unchanged but the jitter still triggers HA service calls. Expected reduction: ~10x fewer writes during heavy-import periods (most of the day).

## What changed

- Single line: `image.tag: 0.2.0 → 0.3.0` in `kubernetes/apps/home-automation/zero-export-controller/app/helmrelease.yaml`.
- No manifest tunables added — `SATURATION_GRID_THRESHOLD_W=400` and `SATURATION_DEADBAND_W=50` are baked-in defaults in v0.3.0 and only need explicit env vars if we want to override them.
- New metrics exposed by the controller's `/metrics`:
  - `zec_effective_deadband_watts` (gauge — should read 5 when grid ≤ 400 W, 50 when grid > 400 W)
  - `zec_writes_skipped_total{reason="deadband"}` (counter — should grow during saturation)

## Safety / invariants

- Behaviour-only change to write cadence; the underlying export-control logic, per-inverter caps, and the `sum(limits) ≤ 900 W` legal-cap invariant are unchanged.
- AlertManager rules (PodNotReady / PodCrashLooping / PodRestarted, plus the 950 W legal-cap alert raised in #145) remain in force.

## Test plan

- [ ] Flux reconciles HelmRelease; new pod comes up Running, 0 restarts, image tag `0.3.0`.
- [ ] Confirm `sum(limits) ≤ 900 W` invariant holds across all inverters post-rollout.
- [ ] Count `number.set_value` calls in a 5-minute window under similar grid conditions (> 400 W) on v0.3.0 and compare to the 26/5min v0.2.0 baseline — expect ~10x cut.
- [ ] `/metrics`: verify `zec_effective_deadband_watts` reading and that `zec_writes_skipped_total{reason="deadband"}` is incrementing during saturation.
- [ ] Capture 5 fresh log lines from the new pod for the report.
- [ ] AlertManager: no new firing alerts for `home-automation/zero-export-controller`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)