### PR TITLE
fix(ingress-nginx): remove duplicate enable-real-ip key

### DIFF
--- a/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml
+++ b/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml
@@ -71,7 +71,6 @@ spec:
         # nginx's $remote_addr / metrics reflect the public IP, not the
         # tunnel's internal cluster IP. Cloudflare-injected headers are
         # already validated upstream of us; cf-tunnel is the only path here.
-        enable-real-ip: "true"
         forwarded-for-header: "CF-Connecting-IP"
         proxy-body-size: 0
         proxy-buffer-size: 16k


### PR DESCRIPTION
## Summary

Commit `e6816990` (cf-connecting-ip support) introduced a duplicate `enable-real-ip: "true"` key in `kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml`. The same key already existed ~20 lines above, so the addition is functionally a no-op — but it's a YAML duplicate-mapping-key that fails Flux Local CI's strict YAML parse, blocking every subsequent PR (notably #146, zero-export-controller v0.3.0).

## Change

- Drop the duplicate `enable-real-ip: "true"` line.
- Keep the four-line explanatory comment block — it correctly documents the original (still-present) line above.

One-line diff. No behavioral change to ingress-nginx — trust-real-IP was already enabled and remains enabled.

## Test plan

- [x] `kubeconform -strict` passes on `kubernetes/apps/network/external/ingress-nginx/` (1 resource, 0 errors)
- [x] `task kubeconform` shows no new errors (the 2 pre-existing pallet-price-monitor errors are unrelated)
- [x] Pre-commit secret scan: clean
- [ ] Flux Local CI green on this PR
- [ ] After merge: confirm PR #146 CI re-runs and goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)