### PR TITLE
feat(arag-web): bump image to sha-fcedf2f

### DIFF
--- a/kubernetes/apps/office/arag-web/app/helmrelease.yaml
+++ b/kubernetes/apps/office/arag-web/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
           app:
             image:
               repository: ghcr.io/nachtschatt3n/arag-web
-              tag: sha-5149163
+              tag: sha-fcedf2f
               pullPolicy: Always
             env:
               RAILS_ENV: production


### PR DESCRIPTION
Bump arag-web image to sha-fcedf2f (provider enrichment + provider-based payment re-matching). CI green.

Validation: task kubeconform clean for arag-web (Invalid: 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)