### PR TITLE
feat(arag-web): bump image to sha-b539520

### DIFF
--- a/kubernetes/apps/office/arag-web/app/helmrelease.yaml
+++ b/kubernetes/apps/office/arag-web/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
           app:
             image:
               repository: ghcr.io/nachtschatt3n/arag-web
-              tag: sha-fcedf2f
+              tag: sha-b539520
               pullPolicy: Always
             env:
               RAILS_ENV: production


### PR DESCRIPTION
Bump arag-web image to `sha-b539520` (widened payment-match window). CI green.

After rollout: re-run sure matching + lifecycle builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)